### PR TITLE
Added vscode gopls settings.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "gopls": {
+        "build.buildFlags": [
+            "-tags=integration"
+        ]
+    },
+}


### PR DESCRIPTION
Without these settings `gopls` won't work on files tagged `//go:build integration`.