### PR TITLE
Validate the uma address data included in requests

### DIFF
--- a/examples/uma-server/validators.go
+++ b/examples/uma-server/validators.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+func ValidateUmaAddress(address string) error {
+	addressParts := strings.Split(address, "@")
+	if len(addressParts) != 2 {
+		return errors.New("invalid receiver address")
+	}
+	receiverId := addressParts[0]
+	receiverVasp := addressParts[1]
+	userNameError := ValidateUserName(receiverId)
+	if userNameError != nil {
+		return userNameError
+	}
+	domainError := ValidateDomain(receiverVasp)
+	if domainError != nil {
+		return domainError
+	}
+	return nil
+}
+
+func ValidateUserName(userName string) error {
+	userNameRegex := regexp.MustCompile(`^\$?[a-zA-Z0-9-._+]+$`)
+	if !userNameRegex.MatchString(userName) {
+		return errors.New("invalid UMA user name")
+	}
+	return nil
+}
+
+func ValidateDomain(domain string) error {
+	localHostWithPortRegex := regexp.MustCompile(`^localhost(:[0-9]+)?$`)
+	domainRegex := regexp.MustCompile(`^([a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62}){1}(\.[a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62})*[._]?$`)
+	if !domainRegex.MatchString(domain) && !localHostWithPortRegex.MatchString(domain) {
+		return errors.New("invalid VASP domain")
+	}
+	return nil
+}

--- a/examples/uma-server/vasp1.go
+++ b/examples/uma-server/vasp1.go
@@ -40,14 +40,15 @@ func NewVasp1(config *UmaConfig, pubKeyCache uma.PublicKeyCache) *Vasp1 {
 
 func (v *Vasp1) handleClientUmaLookup(context *gin.Context) {
 	receiverAddress := context.Param("receiver")
-	addressParts := strings.Split(receiverAddress, "@")
-	if len(addressParts) != 2 {
+	err := ValidateUmaAddress(receiverAddress)
+	if err != nil {
 		context.JSON(http.StatusBadRequest, gin.H{
 			"status": "ERROR",
 			"reason": "Invalid receiver address",
 		})
 		return
 	}
+	addressParts := strings.Split(receiverAddress, "@")
 	receiverId := addressParts[0]
 	receiverVasp := addressParts[1]
 	signingKey, err := v.config.UmaSigningPrivKeyBytes()

--- a/examples/uma-server/vasp2.go
+++ b/examples/uma-server/vasp2.go
@@ -123,6 +123,14 @@ func (v *Vasp2) parseUmaQueryData(context *gin.Context) ([]byte, bool) {
 		return nil, true
 	}
 
+	vaspDomainValidationErr := ValidateDomain(query.VaspDomain)
+	if vaspDomainValidationErr != nil {
+		context.JSON(http.StatusBadRequest, gin.H{
+			"status": "ERROR",
+			"reason": fmt.Sprintf("Invalid sending VASP domain: %v", vaspDomainValidationErr),
+		})
+		return nil, true
+	}
 	pubKeys, err := uma.FetchPublicKeyForVasp(query.VaspDomain, v.pubKeyCache)
 	if err != nil || pubKeys == nil {
 		context.JSON(http.StatusBadRequest, gin.H{
@@ -289,7 +297,8 @@ func (v *Vasp2) handleUmaPayreq(context *gin.Context) {
 	}
 
 	sendingVaspDomain, err := uma.GetVaspDomainFromUmaAddress(request.PayerData.Identifier)
-	if err != nil {
+	addressValidationError := ValidateUmaAddress(request.PayerData.Identifier)
+	if err != nil || addressValidationError != nil {
 		context.JSON(http.StatusBadRequest, gin.H{
 			"status": "ERROR",
 			"reason": fmt.Sprintf("Invalid sender indentifier. UMA address required in the format $alice@vasp.com: %v", err),

--- a/examples/uma-server/vasp2.go
+++ b/examples/uma-server/vasp2.go
@@ -297,11 +297,18 @@ func (v *Vasp2) handleUmaPayreq(context *gin.Context) {
 	}
 
 	sendingVaspDomain, err := uma.GetVaspDomainFromUmaAddress(request.PayerData.Identifier)
-	addressValidationError := ValidateUmaAddress(request.PayerData.Identifier)
-	if err != nil || addressValidationError != nil {
+	if err != nil {
 		context.JSON(http.StatusBadRequest, gin.H{
 			"status": "ERROR",
 			"reason": fmt.Sprintf("Invalid sender indentifier. UMA address required in the format $alice@vasp.com: %v", err),
+		})
+		return
+	}
+	addressValidationError := ValidateUmaAddress(request.PayerData.Identifier)
+	if addressValidationError != nil {
+		context.JSON(http.StatusBadRequest, gin.H{
+			"status": "ERROR",
+			"reason": fmt.Sprintf("Invalid sender indentifier. UMA address required in the format $alice@vasp.com: %v", addressValidationError),
 		})
 		return
 	}


### PR DESCRIPTION
This addresses some SSRF risks associated with the demo vasp. Note that a real vasp might also do additional domain whitelisting, checks,  or validation of the vasps they communicate with.