### PR TITLE
Fix ordering of parameters when signing

### DIFF
--- a/requester/signing_key.go
+++ b/requester/signing_key.go
@@ -31,7 +31,7 @@ func (s *Secp256k1SigningKey) Sign(payload []byte) ([]byte, error) {
 	if error != nil {
 		return nil, error
 	}
-	return lightspark_crypto.SignEcdsa(keyBytes, payload)
+	return lightspark_crypto.SignEcdsa(payload, keyBytes)
 }
 
 type RsaSigningKey struct {


### PR DESCRIPTION
Context:
this seems to be causing the error `CryptoError: Secp256k1Error: Secp256k1 error malformed or out-of-range secret key` due to the payload being used as a key accidentally