### PR TITLE
Fix hermetic integration tests

### DIFF
--- a/examples/lnurl-server/go.mod
+++ b/examples/lnurl-server/go.mod
@@ -1,8 +1,6 @@
 module github.com/lightsparkdev/go-sdk/examples/lnurl-server
 
-go 1.21
-
-toolchain go1.21.0
+go 1.20
 
 require (
 	github.com/gin-gonic/gin v1.9.1

--- a/examples/remote-signing-server/go.mod
+++ b/examples/remote-signing-server/go.mod
@@ -1,8 +1,6 @@
 module github.com/lightsparkdev/go-sdk/examples/remote-signing-server
 
-go 1.21
-
-toolchain go1.21.0
+go 1.20
 
 require (
 	github.com/gin-gonic/gin v1.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/lightsparkdev/go-sdk
 
-go 1.21
-
-toolchain go1.21.0
+go 1.20
 
 require (
 	github.com/lightsparkdev/lightspark-crypto-uniffi/lightspark-crypto-go v0.0.2-0.20230921052801-1726ad16b251

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -54,7 +54,8 @@ func ValidateBaseUrl(baseUrl string) error {
 	if err != nil {
 		return errors.New("invalid base url. Not a valid URL")
 	}
-	if parsedUrl.Scheme != "https" && parsedUrl.Hostname() != "localhost" {
+	isWhitelistedLocalHost := parsedUrl.Hostname() == "localhost" || parsedUrl.Hostname() == "app.minikube.local"
+	if parsedUrl.Scheme != "https" && !isWhitelistedLocalHost {
 		return errors.New("invalid base url. Must be https:// if not targeting localhost")
 	}
 	return nil


### PR DESCRIPTION
- Revert toolchain and use go 1.20 for now.
- Allow *.local domains to use https for testing.