### PR TITLE
Load operation signing key directly.

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+
 	"golang.org/x/crypto/pbkdf2"
 
 	lightspark_crypto "github.com/lightsparkdev/lightspark-crypto-uniffi/lightspark-crypto-go"

--- a/requester/signing_key.go
+++ b/requester/signing_key.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
-	"encoding/hex"
 	"errors"
 
 	lightspark_crypto "github.com/lightsparkdev/lightspark-crypto-uniffi/lightspark-crypto-go"
@@ -17,21 +16,11 @@ type SigningKey interface {
 }
 
 type Secp256k1SigningKey struct {
-	MasterSeedBytes []byte
-	Network         lightspark_crypto.BitcoinNetwork
+	PrivateKey []byte
 }
 
 func (s *Secp256k1SigningKey) Sign(payload []byte) ([]byte, error) {
-	derivationPath := "m/5"
-	key, error := lightspark_crypto.DerivePrivateKey(s.MasterSeedBytes, s.Network, derivationPath)
-	if error != nil {
-		return nil, error
-	}
-	keyBytes, error := hex.DecodeString(key)
-	if error != nil {
-		return nil, error
-	}
-	return lightspark_crypto.SignEcdsa(payload, keyBytes)
+	return lightspark_crypto.SignEcdsa(s.PrivateKey, payload)
 }
 
 type RsaSigningKey struct {

--- a/services/signing_key_loader.go
+++ b/services/signing_key_loader.go
@@ -1,7 +1,9 @@
 package services
 
 import (
+	"encoding/hex"
 	"errors"
+
 	"github.com/lightsparkdev/go-sdk/crypto"
 	"github.com/lightsparkdev/go-sdk/objects"
 	"github.com/lightsparkdev/go-sdk/requester"
@@ -76,7 +78,16 @@ func (s *SigningKeyLoader) loadSigningKeyFromMasterSeed() (requester.SigningKey,
 		return nil, errors.New("invalid network")
 	}
 
-	return &requester.Secp256k1SigningKey{MasterSeedBytes: s.masterSeedAndNetwork.masterSeed, Network: network}, nil
+    derivationPath := "m/5"
+    key, error := lightspark_crypto.DerivePrivateKey(s.masterSeedAndNetwork.masterSeed, network, derivationPath)
+    if error != nil {
+        return nil, error
+    }
+    keyBytes, error := hex.DecodeString(key)
+    if error != nil {
+        return nil, error
+    }
+	return &requester.Secp256k1SigningKey{PrivateKey: keyBytes}, nil
 }
 
 func (s *SigningKeyLoader) loadSigningKeyFromIdAndPassword(req requester.Requester) (requester.SigningKey, error) {


### PR DESCRIPTION
- Add a way for client to directly load the signing key.
- From the loader, load the derived key without persisting the seed.