### PR TITLE
Added func ExecuteGraphql to LightsparkClient

### DIFF
--- a/services/lightspark_client.go
+++ b/services/lightspark_client.go
@@ -1041,3 +1041,9 @@ func (client *LightsparkClient) getNodeSigningKey(nodeId string) (requester.Sign
 	}
 	return nodeKey, nil
 }
+
+func (client *LightsparkClient) ExecuteGraphql(query string, variables map[string]interface{},
+	signingKey requester.SigningKey,
+) (map[string]interface{}, error) {
+	return client.Requester.ExecuteGraphql(query, variables, signingKey)
+}


### PR DESCRIPTION
- Added ExecuteGraphql as method to LightsparkClient, now we can create an Interface with all the methods to mock it, because originally in the remote signing examples Requester was being called directly