### PR TITLE
Fix Dockerfile and add it to CI.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,24 @@ on:
     branches: [ "main" ]
 
 jobs:
+  build:
+    runs-on: "ubuntu-22.04"
+    steps:
+    - name: "Setup QEMU"
+      uses: "docker/setup-qemu-action@v2"
+    - name: "Setup builder"
+      uses: "docker/setup-buildx-action@v2"
+    - name: "Checkout"
+      uses: "actions/checkout@v3"
+    - name: "Build and push image"
+      uses: "docker/build-push-action@v3"
+      with:
+        context: .
+        file: Dockerfile
+        platforms: linux/arm64,linux/amd64
+        outputs: type=cacheonly
+        tags: lightsparkdev/go-sdk:latest
+
 
   test:
     runs-on: "ubuntu-22.04"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM --platform=$BUILDPLATFORM golang:1.21-bookworm as builder
+FROM --platform=$BUILDPLATFORM golang:1.22-bookworm AS builder
 
 ARG TARGETOS TARGETARCH
 RUN echo "$TARGETARCH" | sed 's,arm,aarch,;s,amd,x86_,' > /tmp/arch
 RUN apt-get update && apt-get install -y "gcc-$(tr _ - < /tmp/arch)-linux-gnu" && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV GOOS $TARGETOS
-ENV GOARCH $TARGETARCH
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
 
 COPY . /src
 RUN go env
 RUN cd /src/examples/remote-signing-server && CGO_ENABLED=1 CC=$(cat /tmp/arch)-linux-gnu-gcc go install
 RUN if [ -e /go/bin/${TARGETOS}_${TARGETARCH} ]; then mv /go/bin/${TARGETOS}_${TARGETARCH}/* /go/bin/; fi
 
-FROM debian:bookworm as final
+FROM debian:bookworm AS final
 
 RUN addgroup --system --gid 1000 go && adduser --system --uid 1000 --ingroup go go
 RUN apt-get update && apt-get -y install ca-certificates && apt-get clean && rm -rf /var/lib/apt/lists


### PR DESCRIPTION
We updated our Go version in 270293, but since we weren't doing Docker
builds in CI, we didn't realize it was broken. This change updates the
base image for the Dockerfile and adds a basic build to CI that just
throws away the output.

Also fixed some minor warnings that Docker was complaining about in the
Dockerfile (e.g. ENV key=value instead of ENV key value).