### PR TITLE
[remotesigning] Split up sighash and destination validation

### DIFF
--- a/examples/remote-signing-server/server.go
+++ b/examples/remote-signing-server/server.go
@@ -14,7 +14,9 @@ import (
 
 func getValidator(config *Config) remotesigning.Validator {
 	if config.ValidationEnabled {
-		return &remotesigning.HashValidator{}
+		return remotesigning.NewMultiValidator(
+			remotesigning.HashValidator{},
+			remotesigning.DestinationValidator{})
 	} else {
 		return &remotesigning.PositiveValidator{}
 	}
@@ -75,7 +77,7 @@ func main() {
 		case objects.WebhookEventTypeRemoteSigning:
 			if config.RespondDirectly {
 				resp, err := remotesigning.GraphQLResponseForRemoteSigningWebhook(
-					remotesigning.HashValidator{}, *event, config.MasterSeed)
+					validator, *event, config.MasterSeed)
 				if err != nil {
 					log.Printf("ERROR: Unable to handle remote signing webhook: %s", err)
 					c.AbortWithStatus(http.StatusInternalServerError)


### PR DESCRIPTION
A small refactor to split up different validation into separate objects. Currently our `HashValidator` validates both the transaction sighash and the output scripts of L1 wallet transactions. In an upcoming PR, I'd like to remove the xpubs parameter from the validation interface, and just pass the information needed to validate scripts into the specific validator that needs it. We also redundantly validated the sighash in the function to validate scripts and this PR removes that as well.