### PR TITLE
[remotesigning] Validate force closure claims to L1 wallet

### DIFF
--- a/examples/remote-signing-server/config.go
+++ b/examples/remote-signing-server/config.go
@@ -16,6 +16,7 @@ const WEBHOOK_SECRET = "WEBHOOK_SECRET"
 const MASTER_SEED_HEX = "MASTER_SEED_HEX"
 const RESPOND_DIRECTLY = "RESPOND_DIRECTLY"
 const VALIDATION_ENABLED = "VALIDATION_ENABLED"
+const L1_WALLET_ENABLED = "L1_WALLET_ENABLED"
 
 type Config struct {
 	ApiEndpoint       *string
@@ -25,6 +26,7 @@ type Config struct {
 	MasterSeed        []byte
 	RespondDirectly   bool
 	ValidationEnabled bool
+	L1WalletEnabled   bool
 }
 
 func NewConfigFromEnv() (*Config, error) {
@@ -61,6 +63,7 @@ func NewConfigFromEnv() (*Config, error) {
 
 	respondDirectly := lookupEnvBool(RESPOND_DIRECTLY, false)
 	validationEnabled := lookupEnvBool(VALIDATION_ENABLED, true)
+	l1WalletEnabled := lookupEnvBool(L1_WALLET_ENABLED, false)
 
 	log.Print("Loaded configuration:")
 	log.Printf("  - API_ENDPOINT: %s", showEmpty(apiEndpointStr))
@@ -77,6 +80,7 @@ func NewConfigFromEnv() (*Config, error) {
 		MasterSeed:        masterSeed,
 		RespondDirectly:   respondDirectly,
 		ValidationEnabled: validationEnabled,
+		L1WalletEnabled:   l1WalletEnabled,
 	}, nil
 }
 

--- a/examples/remote-signing-server/server.go
+++ b/examples/remote-signing-server/server.go
@@ -35,7 +35,7 @@ func main() {
 	if config.ValidationEnabled {
 		validator = remotesigning.NewMultiValidator(
 			remotesigning.HashValidator{},
-			remotesigning.NewDestinationValidator(config.MasterSeed))
+			remotesigning.NewDestinationValidator(config.MasterSeed, config.L1WalletEnabled))
 	} else {
 		validator = remotesigning.PositiveValidator{}
 	}

--- a/remotesigning/request.go
+++ b/remotesigning/request.go
@@ -2,12 +2,14 @@
 package remotesigning
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightsparkdev/go-sdk/objects"
 	"github.com/lightsparkdev/go-sdk/webhooks"
 )
@@ -507,4 +509,17 @@ func (j *SigningJob) AddTweakBytes() ([]byte, error) {
 
 func (j *SigningJob) MessageBytes() ([]byte, error) {
 	return hex.DecodeString(j.Message)
+}
+
+func (j *SigningJob) BitcoinTx() (wire.MsgTx, error) {
+	txHex := *j.Transaction
+	rawTxBytes, err := hex.DecodeString(txHex)
+	if err != nil {
+		return wire.MsgTx{}, fmt.Errorf("failed to decode transaction hex: %v", err)
+	}
+	var tx wire.MsgTx
+	if err := tx.Deserialize(bytes.NewReader(rawTxBytes)); err != nil {
+		return wire.MsgTx{}, fmt.Errorf("failed to deserialize transaction: %v", err)
+	}
+	return tx, nil
 }

--- a/remotesigning/validator.go
+++ b/remotesigning/validator.go
@@ -107,7 +107,7 @@ func (v DestinationValidator) ShouldSign(webhookEvent webhooks.WebhookEvent) boo
 			(v.validateForceClosureClaims &&
 			isForceClosureClaimSigningJob(signing))
 		if shouldValidateDestination {
-			publicKey, err := DerivePublicKey(v.masterSeed, signing.DerivationPath, &chaincfg.MainNetParams)
+			publicKey, err := DerivePublicKey(v.masterSeed, signing.DestinationDerivationPath, &chaincfg.MainNetParams)
 			if err != nil {
 				return false
 			}


### PR DESCRIPTION
When a user has an L1 wallet, claims on a commitment tx on a force closure should be sent to an address from this wallet. We would like to validate that when we get a signing job for one of these claims, that the destination is this wallet.

To do this, this PR:
- Adds an environment variable flag to enable this validation
- Refactors our `ValidateScript` function which takes a signing job, deserializes its bitcoin tx, and validates an expected change address. Now instead, we deserialize the tx from the signing job in a method on the job itself, then have two functions `ValidateChangeScript` and `ValidateOutputScript`.
- Changes the logic in our `DestinationValidator` to now validate both in the right scenarios

Note: our normal L1 wallet validation only applies to withdrawals, and only validates the change address.