### PR TITLE
Added `paymentHash` to `LightsparkClient.CreateInvoice`.

### DIFF
--- a/scripts/create_invoice.go
+++ b/scripts/create_invoice.go
@@ -10,6 +10,7 @@ mutation CreateInvoice(
     $memo: String
     $invoice_type: InvoiceType
 	$expiry_secs: Int
+    $payment_hash: String
 ) {
     create_invoice(input: {
         node_id: $node_id
@@ -17,6 +18,7 @@ mutation CreateInvoice(
         memo: $memo
         invoice_type: $invoice_type
 		expiry_secs: $expiry_secs
+        payment_hash: $payment_hash
     }) {
         invoice {
             ...InvoiceFragment

--- a/services/lightspark_client.go
+++ b/services/lightspark_client.go
@@ -130,14 +130,18 @@ func (client *LightsparkClient) CreateApiToken(name string, transact bool,
 //	memo: the memo of the invoice
 //	invoiceType: the type of the invoice
 //	expirySecs: the expiry of the invoice in seconds. Default value is 86400 (1 day).
+//	paymentHash: an optional payment hash to use for the invoice. This only applies to remote
+//	             signing nodes. If not provided, it will be requested from the remote signer
+//	             separately.
 func (client *LightsparkClient) CreateInvoice(nodeId string, amountMsats int64,
-	memo *string, invoiceType *objects.InvoiceType, expirySecs *int32,
+	memo *string, invoiceType *objects.InvoiceType, expirySecs *int32, paymentHash *string,
 ) (*objects.Invoice, error) {
 	variables := map[string]interface{}{
 		"amount_msats": amountMsats,
 		"node_id":      nodeId,
 		"memo":         memo,
 		"invoice_type": invoiceType,
+		"payment_hash": paymentHash,
 	}
 	if expirySecs != nil {
 		variables["expiry_secs"] = expirySecs


### PR DESCRIPTION
This allows remote signing customers to specify the payment hash as part
of the request, rather than have Lightspark request it separately upon
invoice creation.