### PR TITLE
Added `LightsparkClient.CreateInvoiceWithPaymentHash` .

### DIFF
--- a/scripts/create_invoice.go
+++ b/scripts/create_invoice.go
@@ -9,14 +9,18 @@ mutation CreateInvoice(
     $amount_msats: Long!
     $memo: String
     $invoice_type: InvoiceType
-	$expiry_secs: Int
+    $expiry_secs: Int
+    $payment_hash: Hash32
+    $preimage_nonce: Hash32
 ) {
     create_invoice(input: {
         node_id: $node_id
         amount_msats: $amount_msats
         memo: $memo
         invoice_type: $invoice_type
-		expiry_secs: $expiry_secs
+        expiry_secs: $expiry_secs
+        payment_hash: $payment_hash
+        preimage_nonce: $preimage_nonce
     }) {
         invoice {
             ...InvoiceFragment


### PR DESCRIPTION
This allows remote signing customers to specify the payment hash as part of the request, rather than have Lightspark request it separately upon invoice creation.